### PR TITLE
Large Refactor and Function Arguments

### DIFF
--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -130,16 +130,14 @@ def process_block(spec, block, flags):
     for comp in get_comps(spec, flags):
         for line in block:
             while "{{Comp." in line:
-                old_line = line
                 line = COMP_MATCH.sub(partial(comp_repl, spec=spec, comp=comp), line)
-                if old_line == line:
-                    raise RuntimeError(f"Could not resolve line '{line}'")
 
             if "{{Attr." in line:
                 for attr in get_attrs(comp, flags):
                     newline = line
                     while "{{Attr." in newline:
                         newline = ATTR_MATCH.sub(partial(attr_repl, spec=spec, attr=attr), newline)
+
                     out += newline + "\n"
             else:
                 out += line + "\n"

--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -27,7 +27,7 @@ def parse_token_string(raw_string: str) -> Token:
 
     Examples:
     "{{Comp.conditional.if_nth_else|2|,|.}}"
-    "{{Comp.Name}}"
+    "{{Comp.name}}"
     """
     assert raw_string.startswith("{{")
     assert raw_string.endswith("}}")

--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -1,5 +1,7 @@
 import re
 import inspect
+from typing import Tuple, Literal
+from dataclasses import dataclass
 from functools import partial
 from Datamatic.Plugins import Plugin
 from Datamatic import Types
@@ -7,6 +9,84 @@ from Datamatic import Types
 
 COMP_MATCH = re.compile(r"(\{\{Comp\..*?\}\})")
 ATTR_MATCH = re.compile(r"(\{\{Attr\..*?\}\})")
+
+
+@dataclass(frozen=True)
+class Token:
+    namespace: Literal["Comp", "Attr"]
+    plugin_name: str
+    function_name: str
+    args: Tuple[str]
+
+
+def parse_token_string(token_string: str) -> Token:
+    """
+    Format:
+    "{{" ("Comp"|"Attr") "." [plugin_name "."] function_name ["|" function_arg]* "}}"
+
+    Examples:
+    "{{Comp.conditional.if_nth_else|2|,|.}}"
+    "{{Comp.Name}}"
+    """
+    assert token_string.startswith("{{")
+    assert token_string.endswith("}}")
+
+    *tokens, last_token = token_string[2:-2].split(".")
+    last_token, *args = last_token[-1].split("|")
+    tokens = *tokens, last_token
+    args = tuple(args)
+
+    namespace = tokens[0]
+    if len(tokens) == 2:
+        plugin_name = None
+        function_name = tokens[1]
+    elif len(tokens) == 3:
+        plugin_name = tokens[1]
+        function_name = tokens[2]
+    else:
+        raise RuntimeError(f"Invalid token {token_string}")
+
+    return Token(
+        namespace=namespace,
+        plugin_name=plugin_name,
+        function_name=function_name,
+        args=args
+    )
+
+
+def plugin_repl(spec, obj, token):
+    """
+    Handles plugin substitution for component and attribute methods. The symbols are
+    what occur in the dm file and describe what lookup or plugin we are using, and
+    whether we are had
+    """
+    function = Plugin.get_function(token.namespace, token.plugin_name, token.function_name)
+
+    # The plugin function may request extra information by having
+    # certain parameters in the signature, here we now inspect the
+    # function signature and bind any requested information.
+    sig = inspect.signature(function)
+
+    assert len(sig.parameters) > 0, f"Invalid function signature for {token}"
+    
+    unknown_params = set(sig.parameters.keys()) - {token.namespace.lower(), "args", "spec"}
+    assert not unknown_params, f"Invalid parameter name(s) for {token}: {','.join(unknown_params)}"
+    params = {}
+
+    # If the function has a "args" parameter, bind the
+    # args. If it doesn't assert that there were no args; if they
+    # are specified then they must at least be requested (the
+    # function may just ignore them).
+    if "args" in sig.parameters:
+        params["args"] = token.args
+    else:
+        assert len(token.args) == 0
+
+    # If the function requests the spec, then pass it in.
+    if "spec" in sig.parameters:
+        params["spec"] = spec
+
+    return function(obj, **params)
 
 
 def comp_repl(matchobj, spec, comp):
@@ -17,98 +97,42 @@ def comp_repl(matchobj, spec, comp):
     Or a plugin call with optional args:
     "Comp.<plugin_name>.<function_name>(|<argument>)*"
     """
-    symbols = matchobj.group(1)[2:-2].split(".")
-    assert len(symbols) in {2, 3}
+    token = parse_token_string(matchobj.group(1))
 
-    if len(symbols) == 2:
-        namespace, trait = symbols
-        assert namespace == "Comp" 
-
-        if value := comp.get(trait):
+    if token.plugin_name is None:
+        if value := comp.get(token.function_name):
             if isinstance(value, bool):
                 return "true" if value else "false"
             if isinstance(value, str):
                 return value
-        raise RuntimeError(f"Accessing invalid attr {trait}")
 
-    elif len(symbols) == 3:
-        namespace, plugin_name, trait_and_args = symbols
-        trait, *args = trait_and_args.split("|")
-        assert namespace == "Comp"
-
-        plugin = Plugin.get(plugin_name)
-        func = getattr(plugin, trait)
-        assert func.__type == "Comp"
-
-        # The plugin function may request extra information by having
-        # certain parameters in the signature, here we now inspect the
-        # function signature and bind any requested information.
-        sig = inspect.signature(func)
-
-        assert len(sig.parameters) > 0, f"Invalid function signature for {plugin_name}.{trait}, requires a 'comp' parameter"
-        
-        unknown_params = set(sig.parameters.keys()) - {"comp", "args", "spec"}
-        assert not unknown_params, f"Invalid parameter name(s) for {plugin_name}.{trait}: {','.join(unknown_params)}"
-        params = {}
-
-        # If the function has a "args" parameter, bind the
-        # args. If it doesn't assert that there were no args; if they
-        # are specified then they must at least be requested (the
-        # function may just ignore them).
-        if "args" in sig.parameters:
-            params["args"] = args
-        else:
-            assert len(args) == 0
-
-        # If the function requests the spec, then pass it in.
-        if "spec" in sig.parameters:
-            params["spec"] = spec
-
-        return func(comp, **params)
+        raise RuntimeError(f"Accessing invalid attr {token.function_name}")
 
     else:
-        raise RuntimeError(f"Invalid line {symbols}")
+        return plugin_repl(spec, comp, token)
+
+    raise RuntimeError(f"Invalid line {symbols}")
 
 
 def attr_repl(matchobj, spec, attr):
-    symbols = matchobj.group(1)[2:-2].replace(":", ".").split(".")
-    assert len(symbols) in {2, 3}
+    token = parse_token_string(matchobj.group(1))
 
-    if len(symbols) == 2:
-        namespace, trait = symbols
-        assert namespace == "Attr" 
-
-        if trait == "Default":
+    if token.plugin_name is None:
+        if token.function_name == "Default":
             cls = Types.get(attr["Type"])
-            return repr(cls(attr[trait]))
+            return repr(cls(attr[token.function_name]))
         
-        if value := attr.get(trait):
+        if value := attr.get(token.function_name):
             if isinstance(value, bool):
                 return "true" if value else "false"
             if isinstance(value, str):
                 return value
-        raise RuntimeError(f"Accessing invalid attr {trait}")
+        raise RuntimeError(f"Accessing invalid attr {token.function_name}")
 
-    elif len(symbols) == 3:
-        namespace, plugin_name, trait = symbols
-        assert namespace == "Attr"
-
-        plugin = Plugin.get(plugin_name)
-        func = getattr(plugin, trait)
-        assert func.__type == "Attr"
-
-        # The function can either accept 1 argument or 2. The first
-        # argument is the current component. The optional second is the
-        # entire component spec
-        sig = inspect.signature(func)
-        sig_len = len(sig.parameters)
-        assert sig_len in {1, 2}
-        if sig_len == 1:
-            return func(attr)
-        return func(attr, spec)
-    
     else:
-        raise RuntimeError(f"Invalid line {symbols}")
+        return plugin_repl(spec, attr, token)
+    
+    raise RuntimeError(f"Invalid line {symbols}")
 
 
 def get_attrs(comp, flags):

--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -5,8 +5,8 @@ from Datamatic.Plugins import Plugin
 from Datamatic import Types
 
 
-COMP_MATCH = re.compile(r"(\{\{Comp\.[a-zA-Z \.\(\)]*\}\})")
-ATTR_MATCH = re.compile(r"(\{\{Attr\.[a-zA-Z \.\(\)]*\}\})")
+COMP_MATCH = re.compile(r"(\{\{Comp\..*?\}\})")
+ATTR_MATCH = re.compile(r"(\{\{Attr\..*?\}\})")
 
 
 def comp_repl(matchobj, spec, comp):
@@ -130,7 +130,10 @@ def process_block(spec, block, flags):
     for comp in get_comps(spec, flags):
         for line in block:
             while "{{Comp." in line:
+                old_line = line
                 line = COMP_MATCH.sub(partial(comp_repl, spec=spec, comp=comp), line)
+                if old_line == line:
+                    raise RuntimeError(f"Could not resolve line '{line}'")
 
             if "{{Attr." in line:
                 for attr in get_attrs(comp, flags):

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -26,15 +26,25 @@ def attrmethod(method):
 
 class format(Plugin):
     @compmethod
-    def comma(comp, spec):
-        """
-        Returns a comma for all components except for the last one. This is
-        intended to be used for comma-separated lists with each element on a
-        separate line.
-        """
-        if comp == spec["Components"][-1]:
+    def if_first(comp, args, spec):
+        [token] = args
+        if comp != spec["Components"][0]:
             return ""
-        return ","
+        return token
+
+    @compmethod
+    def if_not_first(comp, args, spec):
+        [token] = args
+        if comp == spec["Components"][0]:
+            return ""
+        return token
+
+    @compmethod
+    def if_last(comp, args, spec):
+        [token] = args
+        if comp != spec["Components"][-1]:
+            return ""
+        return token
 
     @compmethod
     def if_not_last(comp, args, spec):
@@ -42,3 +52,18 @@ class format(Plugin):
         if comp == spec["Components"][-1]:
             return ""
         return token
+
+    @compmethod
+    def if_nth(comp, args, spec):
+        [token, n] = args
+        if comp != spec["Components"][int(n)]:
+            return ""
+        return token
+
+    @compmethod
+    def if_not_nth(comp, args, spec):
+        [token, n] = args
+        if comp == spec["Components"][int(n)]:
+            return ""
+        return token
+        

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -51,12 +51,12 @@ class builtin(Plugin):
     # Accessors
 
     @compattrmethod
-    def Name(cls, comp):
-        return comp["Name"]
+    def Name(cls, obj):
+        return obj["Name"]
 
     @compattrmethod
-    def DisplayName(cls, comp):
-        return comp["DisplayName"]
+    def DisplayName(cls, obj):
+        return obj["DisplayName"]
 
     @attrmethod
     def Type(cls, attr):

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -51,19 +51,19 @@ class builtin(Plugin):
     # Accessors
 
     @compattrmethod
-    def Name(cls, obj):
+    def name(cls, obj):
         return obj["Name"]
 
     @compattrmethod
-    def DisplayName(cls, obj):
+    def display_name(cls, obj):
         return obj["DisplayName"]
 
     @attrmethod
-    def Type(cls, attr):
+    def type(cls, attr):
         return attr["Type"]
 
     @attrmethod
-    def Default(cls, attr):
+    def default(cls, attr):
         cls = Types.get(attr["Type"])
         return repr(cls(attr["Default"]))
 

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -42,6 +42,14 @@ def compattrmethod(method):
 
 
 class builtin(Plugin):
+    """
+    The default plugin. When parsing a token to replace, if there are only two parameters,
+    this is the assumed plugin. Contains simple accessors and some other helpers.
+    """
+
+
+    # Accessors
+
     @compattrmethod
     def Name(cls, comp):
         return comp["Name"]
@@ -60,7 +68,8 @@ class builtin(Plugin):
         return repr(cls(attr["Default"]))
 
 
-class conditional(Plugin):
+    # Conditional helpers
+
     @compmethod
     def if_nth_else(cls, comp, args, spec):
         [n, yes_token, no_token] = args

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -23,13 +23,14 @@ def attrmethod(method):
     method.__type = "Attr"
     return classmethod(method)
 
+
+# BUITLIN PLUGINS
+
 class conditional(Plugin):
     @compmethod
     def if_nth_else(cls, comp, args, spec):
-        [n, success_token, fail_token] = args
-        if comp != spec["Components"][int(n)]:
-            return fail_token
-        return success_token
+        [n, yes_token, no_token] = args
+        return yes_token if comp == spec["Components"][int(n)] else no_token
 
     @compmethod
     def if_first(cls, comp, args, spec):
@@ -50,4 +51,3 @@ class conditional(Plugin):
     def if_not_last(cls, comp, args, spec):
         [token] = args
         return cls.if_nth_else(comp, ["-1", "", token], spec)
-        

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -16,54 +16,38 @@ class Plugin:
 
 def compmethod(method):
     method.__type = "Comp"
-    return staticmethod(method)
+    return classmethod(method)
 
 
 def attrmethod(method):
     method.__type = "Attr"
-    return staticmethod(method)
+    return classmethod(method)
 
-
-class format(Plugin):
+class conditional(Plugin):
     @compmethod
-    def if_first(comp, args, spec):
-        [token] = args
-        if comp != spec["Components"][0]:
-            return ""
-        return token
-
-    @compmethod
-    def if_not_first(comp, args, spec):
-        [token] = args
-        if comp == spec["Components"][0]:
-            return ""
-        return token
-
-    @compmethod
-    def if_last(comp, args, spec):
-        [token] = args
-        if comp != spec["Components"][-1]:
-            return ""
-        return token
-
-    @compmethod
-    def if_not_last(comp, args, spec):
-        [token] = args
-        if comp == spec["Components"][-1]:
-            return ""
-        return token
-
-    @compmethod
-    def if_nth(comp, args, spec):
-        [token, n] = args
+    def if_nth_else(cls, comp, args, spec):
+        [n, success_token, fail_token] = args
         if comp != spec["Components"][int(n)]:
-            return ""
-        return token
+            return fail_token
+        return success_token
 
     @compmethod
-    def if_not_nth(comp, args, spec):
-        [token, n] = args
-        if comp == spec["Components"][int(n)]:
-            return ""
-        return token
+    def if_first(cls, comp, args, spec):
+        [token] = args
+        return cls.if_nth_else(comp, ["0", token, ""], spec)
+
+    @compmethod
+    def if_not_first(cls, comp, args, spec):
+        [token] = args
+        return cls.if_nth_else(comp, ["0", "", token], spec)
+
+    @compmethod
+    def if_last(cls, comp, args, spec):
+        [token] = args
+        return cls.if_nth_else(comp, ["-1", token, ""], spec)
+
+    @compmethod
+    def if_not_last(cls, comp, args, spec):
+        [token] = args
+        return cls.if_nth_else(comp, ["-1", "", token], spec)
         

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -16,20 +16,19 @@ class Plugin:
     @classmethod
     def get_function(cls, namespace, plugin_name, function_name):
         assert namespace in {"Comp", "Attr"}
-        
-        plugin = Plugin.get(plugin_name)
-        function = getattr(plugin, function_name)
-        assert function.__type == namespace
+
+        function = getattr(Plugin.get(plugin_name), function_name)
+        assert function._type == namespace
         return function
 
 
 def compmethod(method):
-    method.__type = "Comp"
+    method._type = "Comp"
     return classmethod(method)
 
 
 def attrmethod(method):
-    method.__type = "Attr"
+    method._type = "Attr"
     return classmethod(method)
 
 

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -13,6 +13,15 @@ class Plugin:
                 return c
         raise RuntimeError(f"Could not find plugin {name}")
 
+    @classmethod
+    def get_function(cls, namespace, plugin_name, function_name):
+        assert namespace in {"Comp", "Attr"}
+        
+        plugin = Plugin.get(plugin_name)
+        function = getattr(plugin, function_name)
+        assert function.__type == namespace
+        return function
+
 
 def compmethod(method):
     method.__type = "Comp"

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -35,3 +35,10 @@ class format(Plugin):
         if comp == spec["Components"][-1]:
             return ""
         return ","
+
+    @compmethod
+    def if_not_last(comp, args, spec):
+        [token] = args
+        if comp == spec["Components"][-1]:
+            return ""
+        return token

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -22,3 +22,16 @@ def compmethod(method):
 def attrmethod(method):
     method.__type = "Attr"
     return staticmethod(method)
+
+
+class format(Plugin):
+    @compmethod
+    def comma(comp, spec):
+        """
+        Returns a comma for all components except for the last one. This is
+        intended to be used for comma-separated lists with each element on a
+        separate line.
+        """
+        if comp == spec["Components"][-1]:
+            return ""
+        return ","

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -3,6 +3,7 @@ A module that holds Plugin, a base class for plugins to Datamatic.
 Users can implement plugins that hook up to tokens in dm files for
 custom behaviour.
 """
+from Datamatic import Types
 
 
 class Plugin:
@@ -16,23 +17,48 @@ class Plugin:
     @classmethod
     def get_function(cls, namespace, plugin_name, function_name):
         assert namespace in {"Comp", "Attr"}
-
         function = getattr(Plugin.get(plugin_name), function_name)
-        assert function._type == namespace
+        assert hasattr(function, f"_{namespace}"), f"{function_name} is not in the namespace {namespace}"
         return function
 
 
 def compmethod(method):
-    method._type = "Comp"
+    method._Comp = None
     return classmethod(method)
 
 
 def attrmethod(method):
-    method._type = "Attr"
+    method._Attr = None
+    return classmethod(method)
+
+
+def compattrmethod(method):
+    method._Comp = None
+    method._Attr = None
     return classmethod(method)
 
 
 # BUITLIN PLUGINS
+
+
+class builtin(Plugin):
+    @compattrmethod
+    def Name(cls, comp):
+        return comp["Name"]
+
+    @compattrmethod
+    def DisplayName(cls, comp):
+        return comp["DisplayName"]
+
+    @attrmethod
+    def Type(cls, attr):
+        return attr["Type"]
+
+    @attrmethod
+    def Default(cls, attr):
+        cls = Types.get(attr["Type"])
+        return repr(cls(attr["Default"]))
+
 
 class conditional(Plugin):
     @compmethod


### PR DESCRIPTION
* Enhance the plugin system, and make all functionality flow through it. Now, if a plugin name is not specified, rather than doing an attribute lookup inside a component or an attribute (and maybe applying some hard-coded logic), the new default plugin `builtin` is assumed. Previous syntax of attribute access is now reinterpreted as calling a function with the same name and returning the correct data. The special hard-coded logic is now in plugin functions and the whole implementation is easier to read.
* Added a `Token` class and a cleaner parser for the replacement tokens.
* `compmethod` and `attrmethod` are now wrappers for `classmethod` as plugin functions found it useful to refer to other functions within the plugin.
* Added `compattrmethod` to declare a function can be used as both a `compmethod` and a `attrmethod`.
* Stop passing `flags` to plugin functions as it was never used or needed.
* Added the ability for plugin functions to have arguments in the dm code. These arguments are separated by a `|` pipe.
* Added signature inspection for plugin functions, allowing them to request additional info just by declaring the parameter. If the function has `spec`, they can get access to the entire component spec. Getting access to the function parameters in the dm file is done via specifying an `args` parameter. Checks are in place to make sure that tokens have args if and only if the corresponding plugin function expects args.
* Added `if_first`, `if_not_first`, `if_last`, `is_not_last` and `if_nth_else` to the `builtin` plugin. `if_not_last` is actually the primary motivator for most of these changes. This makes use of being able to see the entire spec to see if the current component is the last one. If it isn't, `if_not_last` can be used to place a comma at the end of the line. An example use case of this is declaring a C++ type templated on all component types. This needs a comma separated list of type names which cannot have a trailing comma.