### PR TITLE
New Types API

### DIFF
--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -4,7 +4,6 @@ from typing import Tuple, Literal
 from dataclasses import dataclass
 from functools import partial
 from Datamatic.Plugins import Plugin
-from Datamatic import Types
 
 
 TOKEN = re.compile(r"\{\{(.*?)\}\}")

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -64,8 +64,7 @@ class builtin(Plugin):
 
     @attrmethod
     def default(cls, attr):
-        cls = Types.get(attr["type"])
-        return repr(cls(attr["default"]))
+        return Types.parse(attr["type"], attr["default"])
 
 
     # Conditional helpers

--- a/Datamatic/Types.py
+++ b/Datamatic/Types.py
@@ -3,7 +3,6 @@ A module that holds CppType, a base class for classes that represent
 C++ types. Users can subclass this to add their own types to
 Datamatic.
 """
-from functools import wraps
 
 
 PARSERS = {}
@@ -23,7 +22,7 @@ def register(typename):
     Functions that can be registered should have the signature (str, json_object).
     """
     def decorator(func):
-        assert typename not in PARSERS
+        assert typename not in PARSERS, f"'{typename}' already has a registered parser"
         PARSERS[typename] = func
         return func
     return decorator

--- a/Datamatic/Types.py
+++ b/Datamatic/Types.py
@@ -3,108 +3,61 @@ A module that holds CppType, a base class for classes that represent
 C++ types. Users can subclass this to add their own types to
 Datamatic.
 """
-from abc import ABC, abstractmethod
+from functools import wraps
 
 
-class Type(ABC):
+PARSERS = {}
+
+
+def parse(typename, obj) -> str:
     """
-    Base type for all types used in Datamatic. Subclass this to add
-    extra types.
+    Parse the given object as the given type. A KeyError is raised if there is no
+    parser registered for the given type.
     """
-
-    @abstractmethod
-    def __init__(self):
-        """
-        This should contain asserts to verify that the construction of
-        this object was successful. This will be used in the validator
-        to make sure the schema provided to Datamatic is valid.
-        """
-
-    @abstractmethod
-    def __repr__(self):
-        """
-        This should return a string representation of how this object
-        will look in C++.
-        """
-
-    @staticmethod
-    @abstractmethod
-    def typename():
-        """
-        This should return a string representation of how this type
-        will look in C++.
-        """
+    return PARSERS[typename](typename, obj)
 
 
-class Integer(Type):
-    def __init__(self, val):
-        assert isinstance(val, int)
-        self.val = val
-
-    def __repr__(self):
-        return str(self.val)
-
-    @staticmethod
-    def typename():
-        return "int"
-
-
-class Float(Type):
-    def __init__(self, val):
-        assert isinstance(val, (int, float))
-        self.val = val
-
-    def __repr__(self):
-        if "." not in str(self.val):
-            return f"{self.val}.0f"
-        return f"{self.val}f"
-
-    @staticmethod
-    def typename():
-        return "float"
+def register(typename):
+    """
+    A decorator to be used to register a function as the parser for the specified type.
+    Functions that can be registered should have the signature (str, json_object).
+    """
+    def decorator(func):
+        assert typename not in PARSERS
+        PARSERS[typename] = func
+        return func
+    return decorator
 
 
-class Boolean(Type):
-    def __init__(self, val):
-        assert isinstance(val, bool)
-        self.val = val
-
-    def __repr__(self):
-        return "true" if self.val else "false"
-
-    @staticmethod
-    def typename():
-        return "bool"
+@register("int")
+def _(typename, obj) -> str:
+    assert isinstance(obj, int)
+    return str(obj)
 
 
-class String(Type):
-    def __init__(self, val):
-        assert isinstance(val, str)
-        self.val = val
-
-    def __repr__(self):
-        return f'"{self.val}"'
-
-    @staticmethod
-    def typename():
-        return "std::string"
-    
-   
-class Any(Type):
-    def __init__(self, val):
-        pass
-    
-    def __repr__(self):
-        return "std::any{}"
-    
-    @staticmethod
-    def typename():
-        return "std::any"
+@register("float")
+def _(typename, obj) -> str:
+    assert isinstance(obj, (int, float))
+    if "." not in str(obj):
+        return f"{obj}.0f"
+    return f"{obj}f"
 
 
-def get(typename):
-    for cls in Type.__subclasses__():
-        if cls.typename() == typename:
-            return cls
-    print(f"Could not find {typename}")
-    return None
+@register("double")
+def _(typename, obj) -> str:
+    assert isinstance(obj, (int, float))
+    if "." not in str(obj):
+        return f"{obj}.0"
+    return f"{obj}"
+
+
+@register("bool")
+def _(typename, obj) -> str:
+    assert isinstance(obj, bool)
+    return "true" if obj else "false"
+
+
+@register("std::string")
+def _(typename, obj) -> str:
+    assert isinstance(obj, str)
+    return f'"{obj}"'

--- a/Datamatic/Validator.py
+++ b/Datamatic/Validator.py
@@ -2,7 +2,7 @@
 Validates a given schema to make sure it is well-formed. This should
 also serve as documentation for what makes a valid schema.
 """
-from Datamatic import Types
+from Datamatic import Plugins
 
 
 COMP_KEYS_REQ = {
@@ -47,7 +47,8 @@ def validate_attribute(attr, flags):
     assert isinstance(attr["name"], str), attr
     assert isinstance(attr["display_name"], str), attr
 
-    Types.parse(attr["type"], attr["default"])  # Will assert if invalid
+    # Verify that accessing the default value succeeds.
+    Plugins.builtin.default(attr)
 
     if "flags" in attr:
         assert isinstance(attr["flags"], dict)

--- a/Datamatic/Validator.py
+++ b/Datamatic/Validator.py
@@ -47,9 +47,7 @@ def validate_attribute(attr, flags):
     assert isinstance(attr["name"], str), attr
     assert isinstance(attr["display_name"], str), attr
 
-    cls = Types.get(attr["type"])
-    assert cls is not None
-    cls(attr["default"]) # Will assert if invalid
+    Types.parse(attr["type"], attr["default"])  # Will assert if invalid
 
     if "flags" in attr:
         assert isinstance(attr["flags"], dict)


### PR DESCRIPTION
* Replace the `Type` class with a `parse` function and a `register` function that can be used to extend the `parse` function for custom types. This is inspired by `@functools.singledispatch`.