### PR TITLE
Fix Comp and Attr Generators

### DIFF
--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -91,17 +91,15 @@ def replace_token(matchobj, spec, obj):
 
 
 def get_attrs(comp, flags):
-    attrs = comp["attributes"]
-    for key, value in flags.items():
-        attrs = [x for x in attrs if x["flags"][key] == value]
-    return attrs
+    for attr in comp["attributes"]:
+        if all(attr['flags'][key] == value for key, value in flags.items()):
+            yield attr
 
 
 def get_comps(spec, flags):
-    comps = spec["components"]
-    for key, value in flags.items():
-        comps = [x for x in comps if x["flags"][key] == value]
-    return comps
+    for comp in spec["components"]:
+        if all(comp['flags'][key] == value for key, value in flags.items()):
+            yield comp
 
 
 def process_block(spec, block, flags):


### PR DESCRIPTION
* The generators for looping over components and attributes that have certain flags was completely broken, and was only working in my own examples because I wasn't making use of flags. The new implementations should work as advertised.