### PR TITLE
Replace all Assertions with Exceptions

### DIFF
--- a/datamatic/builtin.py
+++ b/datamatic/builtin.py
@@ -159,13 +159,15 @@ def main(ctx: context.Context):
 
     @ctx.type("std::weak_ptr<{}>")
     def _(typename, subtype, obj) -> str:
-        assert obj is None
+        if obj is not None:
+            raise RuntimeError(f"{typename} must be initialised with null (nullptr)")
         return "nullptr"
 
     @ctx.type("std::any")
     @ctx.type("std::monostate")
     def _(typename, obj) -> str:
-        assert obj is None
+        if obj is not None:
+            raise RuntimeError(f"{typename} must be initialised with null (nullptr)")
         return f"{typename}{{}}"
 
     @ctx.type("std::tuple<{}...>")

--- a/datamatic/context.py
+++ b/datamatic/context.py
@@ -44,15 +44,19 @@ class TypeParser:
     def register(self, first, **kwargs):
         def decorator(func):
             if "{}..." in first:
-                assert first.count("{}") == 1, "Variadic and non-variadic mixing not supported"
+                if first.count("{}") != 1:
+                    raise RuntimeError("Variadic and non-variadic mixing not supported")
                 newfirst = first.replace("{}...", "{}")
-                assert newfirst not in self.variadic_dispatchers, f"'{newfirst}' already has a registered parser"
+                if newfirst in self.variadic_dispatchers:
+                    raise RuntimeError(f"'{newfirst}' already has a registered parser")
                 self.variadic_dispatchers[newfirst] = functools.partial(func, **kwargs)
             elif "{}" in first:
-                assert first not in self.template_dispatchers, f"'{first}' already has a registered parser"
+                if first in self.template_dispatchers:
+                    raise RuntimeError(f"'{first}' already has a registered parser")
                 self.template_dispatchers[first] = functools.partial(func, **kwargs)
             else:
-                assert first not in self.dispatchers, f"'{first}' already has a registered parser"
+                if first in self.dispatchers:
+                    raise RuntimeError(f"'{first}' already has a registered parser")
                 self.dispatchers[first] = functools.partial(func, **kwargs)
             return func
         return decorator
@@ -87,7 +91,8 @@ class Context:
 
     def method(self, namespace, function_name):
         def decorate(function):
-            assert namespace, function_name not in self.methods
+            if (namespace, function_name) in self.methods:
+                raise RuntimeError(f"An implementation already exists for {namespace}::{function_name}")
             self.methods[namespace, function_name] = function
             return function
         return decorate

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -91,7 +91,9 @@ def get_header(dst):
 
 
 def parse_flag_val(val):
-    assert val in {"true", "false"}
+    valid_vals = {"true", "false"}
+    if val not in valid_vals:
+        raise RuntimeError(f"Invalid flag value: {val}, must be one of {valid_vals}")
     return True if val == "true" else False
 
 
@@ -99,7 +101,8 @@ def parse_flags(flags):
     parsed_flags = {}
     for flag in flags:
         flag = flag.split("=")
-        assert len(flag) == 2
+        if len(flag) != 2:
+            raise RuntimeError(f"In correct number of tokens in flag {flag}, must have exactly one '='")
         name = flag[0]
         val = parse_flag_val(flag[1])
         parsed_flags[name] = val
@@ -128,7 +131,8 @@ def run(src, context):
             else:
                 block.append(line)
         elif line.startswith("DATAMATIC_BEGIN"):
-            assert not in_block
+            if in_block:
+                raise RuntimeError("Tried to begin a datamatic block while in another, cannot be nested")
             in_block = True
             flags = parse_flags(set(line.split()[1:]))
         else:

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -123,6 +123,8 @@ def run(src, context):
         line = line.rstrip()
 
         if in_block:
+            if line.startswith("DATAMATIC_BEGIN"):
+                raise RuntimeError("Tried to begin a datamatic block while in another, cannot be nested")
             if line.startswith("DATAMATIC_END"):
                 out += process_block(block, flags, context)
                 in_block = False
@@ -131,8 +133,6 @@ def run(src, context):
             else:
                 block.append(line)
         elif line.startswith("DATAMATIC_BEGIN"):
-            if in_block:
-                raise RuntimeError("Tried to begin a datamatic block while in another, cannot be nested")
             in_block = True
             flags = parse_flags(set(line.split()[1:]))
         else:

--- a/datamatic/validator.py
+++ b/datamatic/validator.py
@@ -3,6 +3,19 @@ Validates a given schema to make sure it is well-formed. This should
 also serve as documentation for what makes a valid schema.
 """
 
+
+class InvalidSpecError(RuntimeError):
+    """
+    Raised if the validation step on the spec file fails.
+    """
+
+
+SCHEMA_KEYS = {
+    "flags",
+    "components"
+}
+
+
 COMP_KEYS_REQ = {
     "name",
     "display_name",
@@ -39,49 +52,69 @@ def validate_attribute(attr, flags, context):
     """
     Asserts that the given attribute is well-formed.
     """
-    assert ATTR_KEYS_REQ <= set(attr.keys()), attr
-    assert set(attr.keys()) <= ATTR_KEYS_REQ | ATTR_KEYS_OPT, attr
+    if set(attr.keys()) < ATTR_KEYS_REQ:
+        raise InvalidSpecError(f"Missing keys for {attr}: {ATTR_KEYS_REQ - set(attr.keys())}")
+    if ATTR_KEYS_REQ | ATTR_KEYS_OPT < set(attr.keys()):
+        raise InvalidSpecError(f"Unrecognised keys for {attr}: {set(attr.keys()) - ATTR_KEYS_REQ | ATTR_KEYS_OPT}")
 
-    assert isinstance(attr["name"], str), attr
-    assert isinstance(attr["display_name"], str), attr
+    if not isinstance(attr["name"], str):
+        raise InvalidSpecError(f"{attr['name']=} must be a {str}, got {type(attr['name'])}")
+    if not isinstance(attr["display_name"], str):
+        raise InvalidSpecError(f"{attr['display_name']=} must be a {str}, got {type(attr['display_name'])}")
 
     # Verify that accessing the default value succeeds.
     context.get("Attr", "default")(attr)
 
     if "flags" in attr:
-        assert isinstance(attr["flags"], dict)
+        if not isinstance(attr["flags"], dict):
+            raise InvalidSpecError(f"{attr['flags']=} must be a {dict}, got {type(attr['display_name'])}")
         for key, val in attr["flags"].items():
-            assert key in flags, f"{key} is not a valid flag"
-            assert isinstance(key, str), attr
-            assert isinstance(val, bool), attr
+            if key not in flags:
+                raise InvalidSpecError(f"{key} is not a valid flag")
+            if not isinstance(key, str):
+                raise InvalidSpecError(f"{key=} must be a {str}, got {type(key)}")
+            if not isinstance(val, bool):
+                raise InvalidSpecError(f"{val=} must be a {bool}, got {type(key)}")
 
 
 def validate_flag(flag):
     """
     Asserts that the given flag is well-formed.
     """
-    assert set(flag.keys()) == FLAG_KEYS, flag
-    assert isinstance(flag["name"], str), flag
-    assert isinstance(flag["default"], bool), flag
+    if set(flag.keys()) != FLAG_KEYS:
+        raise InvalidSpecError(f"Incorrect keys for flag declaration, got {set(flag.keys())}, needed {FLAG_KEYS}")
+    if not isinstance(flag["name"], str):
+        raise InvalidSpecError(f"{flag['name']=} must be a {str}, got {type(flag['name'])}")
+    if not isinstance(flag["default"], bool):
+        raise InvalidSpecError(f"{flag['default']=} must be a {bool}, got {type(flag['default'])}")
 
 
 def validate_component(comp, flags, plugin_list):
     """
     Asserts that the given component is well-formed.
     """
-    assert COMP_KEYS_REQ <= set(comp.keys()), comp
-    assert set(comp.keys()) <= COMP_KEYS_REQ | COMP_KEYS_OPT, comp
+    if set(comp.keys()) < COMP_KEYS_REQ:
+        raise InvalidSpecError(f"Missing keys for {comp}: {COMP_KEYS_REQ - set(comp.keys())}")
+    if COMP_KEYS_REQ | COMP_KEYS_OPT < set(comp.keys()):
+        raise InvalidSpecError(f"Unrecognised keys for {comp}: {set(comp.keys()) - COMP_KEYS_REQ | COMP_KEYS_OPT}")
 
-    assert isinstance(comp["name"], str), comp
-    assert isinstance(comp["display_name"], str), comp
-    assert isinstance(comp["attributes"], list), comp
+    if not isinstance(comp["name"], str):
+        raise InvalidSpecError(f"{comp['name']=} must be a {str}, got {type(comp['name'])}")
+    if not isinstance(comp["display_name"], str):
+        raise InvalidSpecError(f"{comp['display_name']=} must be a {str}, got {type(comp['display_name'])}")
+    if not isinstance(comp["attributes"], list):
+        raise InvalidSpecError(f"{comp['attributes']=} must be a {list}, got {type(comp['attributes'])}")
 
     if "flags" in comp:
-        assert isinstance(comp["flags"], dict)
+        if not isinstance(comp["flags"], dict):
+            raise InvalidSpecError(f"{comp['flags']=} must be a {dict}, got {type(comp['display_name'])}")
         for key, val in comp["flags"].items():
-            assert key in flags, f"{key} is not a valid flag"
-            assert isinstance(key, str), comp
-            assert isinstance(val, bool), comp
+            if key not in flags:
+                raise InvalidSpecError(f"{key} is not a valid flag")
+            if not isinstance(key, str):
+                raise InvalidSpecError(f"{key=} must be a {str}, got {type(key)}")
+            if not isinstance(val, bool):
+                raise InvalidSpecError(f"{val=} must be a {bool}, got {type(key)}")
 
     for attr in comp["attributes"]:
         validate_attribute(attr, flags, plugin_list)
@@ -92,10 +125,16 @@ def run(context):
     Runs the validator against the given spec, raising an exception if there
     is an error in the schema.
     """
-    assert set(context.spec.keys()) == {"flags", "components"}
+    if set(context.spec.keys()) != SCHEMA_KEYS:
+        raise InvalidSpecError(f"Incorrect keys for flag declaration, got {set(context.spec.keys())}, needed {SCHEMA_KEYS}")
 
-    assert isinstance(context.spec["flags"], list)
-    assert isinstance(context.spec["components"], list)
+    spec_flags = context.spec["flags"]
+    if not isinstance(spec_flags, list):
+        raise InvalidSpecError(f"{spec_flags=} must be a {list}, got {type(spec_flags)}")
+
+    spec_components = context.spec["flags"]
+    if not isinstance(spec_flags, list):
+        raise InvalidSpecError(f"{spec_components=} must be a {list}, got {type(spec_components)}")
 
     for flag in context.spec["flags"]:
         validate_flag(flag)

--- a/test/integration/invalid.dm.cpp
+++ b/test/integration/invalid.dm.cpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <string>
+#include <vector>
+
+namespace integration {
+
+// Components
+DATAMATIC_BEGIN
+struct {{Comp::name}}
+{
+    {{Attr::type}} {{Attr::name}} = {{Attr::default}};
+};
+
+DATAMATIC_BEGIN
+    "{{Comp::name}}"{{Comp::if_not_last(,)}}
+DATAMATIC_END
+DATAMATIC_END
+};
+
+
+}

--- a/test/integration/test_end_to_end.py
+++ b/test/integration/test_end_to_end.py
@@ -5,7 +5,7 @@ import tempfile
 import shutil
 import pathlib
 import os.path as op
-from unittest.mock import patch, call
+from unittest.mock import patch
 from datamatic import main
 
 

--- a/test/integration/test_mismatched_datamatic_blocks.py
+++ b/test/integration/test_mismatched_datamatic_blocks.py
@@ -1,0 +1,34 @@
+from datamatic.validator import InvalidSpecError
+import tempfile
+import shutil
+import pathlib
+import os.path as op
+from datamatic import main
+import pytest
+
+
+def test_mismatched_datamatic_blocks():
+    """
+    Verify that trying to nest datamatic blocks is an error.
+    """
+
+    # GIVEN
+    # The directory that this file is in. The template files are also located here.
+    src_dir = op.dirname(op.abspath(__file__))
+
+    # Create a new directory to run the test in.
+    out_dir = tempfile.mkdtemp(prefix="datamatic_")
+    
+    # Copy the template file into the output and verify it's there
+    shutil.copy(op.join(src_dir, "invalid.dm.cpp"), op.join(out_dir, "invalid.dm.cpp"))
+    assert op.exists(op.join(out_dir, "invalid.dm.cpp"))
+
+    shutil.copy(op.join(src_dir, "custom_types.dmx.py"), op.join(out_dir, "custom_types.dmx.py"))
+    assert op.exists(op.join(out_dir, "custom_types.dmx.py"))
+
+    # WHEN
+    specfile = pathlib.Path(src_dir, "component_spec.json")
+
+    # THEN
+    with pytest.raises(RuntimeError):
+        main.main(specfile, pathlib.Path(out_dir))

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -12,7 +12,7 @@ def dummy(typename, obj):
 
 
 def test_typeparser_unregistered_type(ctx):
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         ctx.parse("int", 4)  # Type is not registered
 
 
@@ -55,10 +55,10 @@ def test_variadic_typelist_parser():
 
     assert context.parse_variadic_typelist("std::function<int(bool, float)>, int") == ["std::function<int(bool, float)>", "int"]
     
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         context.parse_variadic_typelist("std::function<int(bool>)")  # Invalid bracket ordering
     
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         context.parse_variadic_typelist("std::pair<")  # Invalid brackets
 
 
@@ -68,7 +68,7 @@ def test_custom_function_lookup_success(ctx):
 
 
 def test_custom_function_lookup_failure(ctx):
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         ctx.get("Attr", "test.func")
 
 
@@ -82,7 +82,17 @@ def test_typeparser_cannot_have_two_variadic_templates(ctx):
     "std::optional<{}>", # template
     "std::tuple<{}...>" # variadic
 ])
-def test_typeparser_cannot_register_a_function_twice(ctx, pattern):
+def test_typeparser_cannot_register_a_type_function_twice(ctx, pattern):
     ctx.type(pattern)(dummy)
     with pytest.raises(RuntimeError):
         ctx.type(pattern)(dummy)
+
+
+def test_context_cannot_register_a_custom_method_twice(ctx):
+    ctx.compmethod("foo")(dummy)
+    with pytest.raises(RuntimeError):
+        ctx.compmethod("foo")(dummy)
+
+    ctx.attrmethod("bar")(dummy)
+    with pytest.raises(RuntimeError):
+        ctx.attrmethod("bar")(dummy)

--- a/test/unit/test_generator.py
+++ b/test/unit/test_generator.py
@@ -78,11 +78,11 @@ def test_parse_flags_bad():
     with pytest.raises(RuntimeError):
         generator.parse_flags(flags)
 
-    flags = ["a=3", "b=true=false"]
+    flags = ["a=true", "b=true=false"]
     with pytest.raises(RuntimeError):
         generator.parse_flags(flags)
 
-    flags = ["a=3", "true"]
+    flags = ["a=false", "true"]
     with pytest.raises(RuntimeError):
         generator.parse_flags(flags)
 

--- a/test/unit/test_generator.py
+++ b/test/unit/test_generator.py
@@ -36,7 +36,7 @@ def test_empty_parentheses_is_valid():
     "Comp::foo(a|b|)"
 ])
 def test_parse_token_string_failure(raw):
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         generator.parse_token_string(raw)
 
 
@@ -57,7 +57,7 @@ def test_parse_flag_value():
     assert generator.parse_flag_val("true") == True
     assert generator.parse_flag_val("false") == False
 
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         generator.parse_flag_val("a")
 
 
@@ -75,15 +75,15 @@ def test_parse_flags_good():
 
 def test_parse_flags_bad():
     flags = ["a=3", "b=2"]
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         generator.parse_flags(flags)
 
     flags = ["a=3", "b=true=false"]
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         generator.parse_flags(flags)
 
     flags = ["a=3", "true"]
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         generator.parse_flags(flags)
 
 

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -1,0 +1,139 @@
+"""
+Validator unit tests.
+"""
+from datamatic import validator, context, builtin
+from datamatic.validator import InvalidSpecError
+import pytest
+
+
+@pytest.fixture
+def ctx():
+    c = context.Context({})
+    builtin.main(c)
+    return c
+
+
+def test_validate_attribute_missing_required_key(ctx):
+    attr = {}
+
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+
+def test_validate_attribute_unknown_keys(ctx):
+    attr = {
+        "name": "",
+        "display_name": "",
+        "type": "int",
+        "default": 0,
+        "extra": None
+    }
+
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+
+def test_validate_attribute_types(ctx):
+    attr = { "name": None, "display_name": "Display", "type": "int", "default": 0 }
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+    attr = { "name": "Name", "display_name": None, "type": "int", "default": 0 }
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+    attr = { "name": "Name", "display_name": "Display", "type": None, "default": 0 }
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+
+def test_validate_flags_on_object():
+    # obj must be a dict
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_on_object([], set())
+
+    # foo is not a valid flag
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_on_object({"foo": True}, {"bar"})
+
+    # keys must be a str
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_on_object({1: True}, {1})
+
+    # value must be a bool
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_on_object({"foo": 1}, {"foo"})
+
+
+def test_validate_flags_in_spec():
+    # flag must have "name" and "default" as keys
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_in_spec({})
+
+    # flag must only have those keys
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_in_spec({"name": "foo", "default": True, "a": None})
+
+    # key must be a string
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_in_spec({1: True})
+
+    # value must be a bool
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_in_spec({"name": 1})
+
+
+def test_validate_component_missing_required_key(ctx):
+    comp = {}
+
+    with pytest.raises(InvalidSpecError):
+        validator.validate_component(comp, [], ctx)
+
+
+def test_validate_component_unknown_keys(ctx):
+    comp = {
+        "name": "",
+        "display_name": "",
+        "attributes": [],
+        "extra": None
+    }
+
+    with pytest.raises(InvalidSpecError):
+        validator.validate_component(comp, [], ctx)
+
+
+def test_validate_component_types(ctx):
+    attr = { "name": None, "display_name": "Display", "attributes": [] }
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+    attr = { "name": "Name", "display_name": None, "attributes": [] }
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+    attr = { "name": "Name", "display_name": "Display", "attributes": None }
+    with pytest.raises(InvalidSpecError):
+        validator.validate_attribute(attr, [], ctx)
+
+
+def test_validator_run(ctx):
+    # doesn't have the correct keys
+    with pytest.raises(InvalidSpecError):
+        validator.run(ctx)
+
+    # has invalid extra keys
+    ctx.spec = {"flags": [], "components": [], "extra": []}
+    with pytest.raises(InvalidSpecError):
+        validator.run(ctx)
+
+
+def test_validator_flags_must_be_a_list(ctx):
+    ctx.spec = {"flags": None, "components": []}
+    with pytest.raises(InvalidSpecError):
+        validator.run(ctx)
+
+
+def test_validator_components_must_be_a_list(ctx):
+    ctx.spec = {"flags": [], "components": None}
+    with pytest.raises(InvalidSpecError):
+        validator.run(ctx)

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -74,13 +74,13 @@ def test_validate_flags_in_spec():
     with pytest.raises(InvalidSpecError):
         validator.validate_flags_in_spec({"name": "foo", "default": True, "a": None})
 
-    # key must be a string
+    # "name" must be a str
     with pytest.raises(InvalidSpecError):
-        validator.validate_flags_in_spec({1: True})
+        validator.validate_flags_in_spec({"name": True, "default": False})
 
-    # value must be a bool
+    # "default" must be a bool
     with pytest.raises(InvalidSpecError):
-        validator.validate_flags_in_spec({"name": 1})
+        validator.validate_flags_in_spec({"name": "flag", "default": "False"})
 
 
 def test_validate_component_missing_required_key(ctx):
@@ -103,17 +103,17 @@ def test_validate_component_unknown_keys(ctx):
 
 
 def test_validate_component_types(ctx):
-    attr = { "name": None, "display_name": "Display", "attributes": [] }
+    comp = { "name": None, "display_name": "Display", "attributes": [] }
     with pytest.raises(InvalidSpecError):
-        validator.validate_attribute(attr, [], ctx)
+        validator.validate_component(comp, [], ctx)
 
-    attr = { "name": "Name", "display_name": None, "attributes": [] }
+    comp = { "name": "Name", "display_name": None, "attributes": [] }
     with pytest.raises(InvalidSpecError):
-        validator.validate_attribute(attr, [], ctx)
+        validator.validate_component(comp, [], ctx)
 
-    attr = { "name": "Name", "display_name": "Display", "attributes": None }
+    comp = { "name": "Name", "display_name": "Display", "attributes": None }
     with pytest.raises(InvalidSpecError):
-        validator.validate_attribute(attr, [], ctx)
+        validator.validate_component(comp, [], ctx)
 
 
 def test_validator_run(ctx):


### PR DESCRIPTION
* So far, all of datamatic has relied on the `assert` statement, which can be disabled. This replaces all assertions in the main code with either `RuntimeError` or the custom `InvalidSpecError` in the validator.
* Coverage will drop, since now any error cases that are not tested will not be covered. Previously assertions are classed as covered even if they never fail as they are a one liner. This will give us insight into having better unit tests.
* Add unit tests to cover the new situations.