### PR TITLE
Simplified Decorators and Context Parameter

### DIFF
--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -13,6 +13,7 @@ class Context:
     spec: list
     comp: dict
     attr: Optional[dict]  # Only populated for attrmethods
+    namespace: str
 
 
 @dataclass(frozen=True)
@@ -86,7 +87,7 @@ def replace_token(matchobj, comp, attr, spec, method_register):
     """
     token = parse_token_string(matchobj.group(1))
     function = method_register.get(token.namespace, token.function_name)
-    ctx = Context(spec=spec, comp=comp, attr=attr)
+    ctx = Context(spec=spec, comp=comp, attr=attr, namespace=token.namespace)
     return function(ctx, *token.args)
 
 

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -170,9 +170,10 @@ def run(src, spec, method_register):
         with dst.open() as dstfile:
             if dstfile.read() == out:
                 print(f"No change to {dst}")
-                return
+                return False
 
     with dst.open("w") as dstfile:
         dstfile.write(out)
 
     print(f"Generated file {dst}")
+    return True

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -13,7 +13,10 @@ class Context:
     spec: list
     comp: dict
     attr: Optional[dict]  # Only populated for attrmethods
-    namespace: str
+
+    @property
+    def namespace(self):
+        return "Attr" if self.attr is not None else "Comp"
 
 
 @dataclass(frozen=True)
@@ -87,7 +90,7 @@ def replace_token(matchobj, comp, attr, spec, method_register):
     """
     token = parse_token_string(matchobj.group(1))
     function = method_register.get(token.namespace, token.function_name)
-    ctx = Context(spec=spec, comp=comp, attr=attr, namespace=token.namespace)
+    ctx = Context(spec=spec, comp=comp, attr=attr)
     return function(ctx, *token.args)
 
 

--- a/datamatic/main.py
+++ b/datamatic/main.py
@@ -40,5 +40,5 @@ def main(specfile: pathlib.Path, directory: pathlib.Path):
         if generator.run(file, spec, reg):
             count += 1
 
-    print("Done!")
+    print(f"Done! Generated {count} files")
     return count

--- a/datamatic/main.py
+++ b/datamatic/main.py
@@ -35,7 +35,10 @@ def main(specfile: pathlib.Path, directory: pathlib.Path):
     reg.load_builtins()
     reg.load_from_dmx(directory)
 
+    count = 0
     for file in directory.glob("**/*.dm.*"):
-        generator.run(file, spec, reg)
+        if generator.run(file, spec, reg):
+            count += 1
 
     print("Done!")
+    return count

--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -15,6 +15,7 @@ class MethodRegister:
     def compmethod(self, function_name=None):
         return self.method("Comp", function_name)
 
+
     def attrmethod(self, function_name=None):
         return self.method("Attr", function_name)
 

--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -5,28 +5,22 @@ custom behaviour.
 """
 import pathlib
 import importlib.util
-from functools import partial
+from functools import partialmethod
 
 
 class MethodRegister:
     def __init__(self):
         self.methods = {}
-    
-    def compmethod(self, function_name=None):
-        return self.method("Comp", function_name)
 
+    def register_method(self, function, namespace):
+        fn_name = function.__name__
+        if (namespace, fn_name) in self.methods:
+            raise RuntimeError(f"An implementation already exists for {namespace}::{fn_name}")
+        self.methods[namespace, fn_name] = function
+        return function
 
-    def attrmethod(self, function_name=None):
-        return self.method("Attr", function_name)
-
-    def method(self, namespace, function_name=None):
-        def decorate(function):
-            fn_name = function_name or function.__name__
-            if (namespace, fn_name) in self.methods:
-                raise RuntimeError(f"An implementation already exists for {namespace}::{fn_name}")
-            self.methods[namespace, fn_name] = function
-            return function
-        return decorate
+    compmethod = partialmethod(register_method, namespace="Comp")
+    attrmethod = partialmethod(register_method, namespace="Attr")
 
     def get(self, namespace, function_name):
         if (namespace, function_name) in self.methods:
@@ -40,8 +34,8 @@ class MethodRegister:
         A function for loading a bunch of built in custom functions.
         """
 
-        @self.compmethod()
-        @self.attrmethod()
+        @self.compmethod
+        @self.attrmethod
         def if_nth_else(ctx, n, yes_token, no_token):
             try:
                 if ctx.namespace == "Comp":
@@ -50,23 +44,23 @@ class MethodRegister:
             except IndexError:
                 return no_token
 
-        @self.compmethod()
-        @self.attrmethod()
+        @self.compmethod
+        @self.attrmethod
         def if_first(ctx, token):
             return if_nth_else(ctx, "0", token, "")
 
-        @self.compmethod()
-        @self.attrmethod()
+        @self.compmethod
+        @self.attrmethod
         def if_not_first(ctx, token):
             return if_nth_else(ctx, "0", "", token)
 
-        @self.compmethod()
-        @self.attrmethod()
+        @self.compmethod
+        @self.attrmethod
         def if_last(ctx, token):
             return if_nth_else(ctx, "-1", token, "")
 
-        @self.compmethod()
-        @self.attrmethod()
+        @self.compmethod
+        @self.attrmethod
         def if_not_last(ctx, token):
             return if_nth_else(ctx, "-1", "", token)
 

--- a/test/integration/actual.dm.cpp
+++ b/test/integration/actual.dm.cpp
@@ -22,7 +22,7 @@ DATAMATIC_END
 
 std::vector<std::string> types_with_flag_b_false = {
 DATAMATIC_BEGIN FLAG_B=false
-    "{{Comp::test.foo}}"{{Comp::if_not_last(,)}}
+    "{{Comp::test_function}}"{{Comp::if_not_last(,)}}
 DATAMATIC_END
 };
 

--- a/test/integration/custom_functions.dmx.py
+++ b/test/integration/custom_functions.dmx.py
@@ -1,5 +1,5 @@
 def main(register):
     
-    @register.compmethod("test.foo")
-    def _(ctx):
+    @register.compmethod
+    def test_function(ctx):
         return "foobar"

--- a/test/integration/custom_functions.dmx.py
+++ b/test/integration/custom_functions.dmx.py
@@ -1,5 +1,5 @@
 def main(register):
     
     @register.compmethod("test.foo")
-    def _(spec, comp):
+    def _(ctx):
         return "foobar"

--- a/test/integration/test_end_to_end.py
+++ b/test/integration/test_end_to_end.py
@@ -3,7 +3,6 @@ An integration test that uses a specfile and a template file.
 """
 import shutil
 from pathlib import Path
-from unittest.mock import patch
 from typing import Optional
 from datamatic import main
 import pytest
@@ -38,7 +37,7 @@ def test_end_to_end_simple(src_path, tmp_path):
     copy_file(src_path, tmp_path, "custom_functions.dmx.py")
 
     specfile = src_path / "component_spec.json"
-    main.main(specfile, tmp_path)
+    assert main.main(specfile, tmp_path) == 1  # Assert one file is generated
 
     expected_file = src_path / "expected.cpp"
     actual_file = tmp_path / "actual.cpp"
@@ -60,7 +59,4 @@ def test_file_is_not_rewritten_if_no_change(src_path, tmp_path):
     copy_file(src_path, tmp_path, "expected.cpp", "actual.cpp")
 
     specfile = src_path / "component_spec.json"
-    with patch("builtins.print") as mock_print:
-        main.main(specfile, tmp_path)
-
-    mock_print.assert_any_call(f"No change to {tmp_path / 'actual.cpp'}")
+    assert main.main(specfile, tmp_path) == 0

--- a/test/unit/test_method_register.py
+++ b/test/unit/test_method_register.py
@@ -67,7 +67,7 @@ def test_context_cannot_register_a_custom_method_twice(reg):
 ])
 def test_property_access_comp(reg, key, value):
     comp = {key: value}
-    ctx = generator.Context(spec=[comp], comp=comp, attr=None, namespace="Comp")
+    ctx = generator.Context(spec=[comp], comp=comp, attr=None)
     assert reg.get("Comp", key)(ctx) == value
 
 
@@ -80,12 +80,12 @@ def test_property_access_comp(reg, key, value):
 def test_property_access_attr(reg, key, value):
     attr = {key: value}
     comp = {"attributes": [attr]}
-    ctx = generator.Context(spec=[], comp=comp, attr=attr, namespace="Attr")
+    ctx = generator.Context(spec=[], comp=comp, attr=attr)
     assert reg.get("Attr", key)(ctx) == value
 
 
 def test_builtin_conditionals_comp(reg, component):
-    ctx = generator.Context(spec=[component], comp=component, attr=None, namespace="Comp")
+    ctx = generator.Context(spec=[component], comp=component, attr=None)
 
     assert reg.get("Comp", "if_nth_else")(ctx, "0", "a", "b") == "a"
     assert reg.get("Comp", "if_nth_else")(ctx, "1", "a", "b") == "b"
@@ -98,7 +98,7 @@ def test_builtin_conditionals_comp(reg, component):
 
 def test_builtin_conditionals_attr(reg, attribute):
     comp = {"attributes": [attribute]}
-    ctx = generator.Context(spec=[comp], comp=comp, attr=attribute, namespace="Attr")
+    ctx = generator.Context(spec=[comp], comp=comp, attr=attribute)
 
     assert reg.get("Attr", "if_nth_else")(ctx, "0", "a", "b") == "a"
     assert reg.get("Attr", "if_nth_else")(ctx, "1", "a", "b") == "b"

--- a/test/unit/test_method_register.py
+++ b/test/unit/test_method_register.py
@@ -1,9 +1,8 @@
 """
 Test driver for the builtin comp and attr methods.
 """
-from datamatic import method_register
+from datamatic import method_register, generator
 import pytest
-from unittest.mock import patch
 
 @pytest.fixture
 def reg():
@@ -60,27 +59,25 @@ def test_context_cannot_register_a_custom_method_twice(reg):
         reg.attrmethod("bar")(dummy)
 
 
-@pytest.mark.parametrize("namespace", [
-    "Comp",
-    "Attr"
-])
 @pytest.mark.parametrize("key,value", [
     ("name", "datamatic"),
     ("display_name", "Datamatic"),
     ("a", "abc"),
     (1, 2)
 ])
-def test_property_access(reg, namespace, key, value):
-    spec = {}  # Empty, as it wont be used here since we are just doing property lookup
+def test_property_access_comp(reg, key, value):
     obj = {key: value}
-    assert reg.get(namespace, key)(spec, obj) == value
+    ctx = generator.Context(spec=[obj], comp=obj, attr=None, namespace="Comp")
+    assert reg.get("Comp", key)(ctx) == value
 
 
 def test_builtin_conditionals(reg, component):
-    assert reg.get("Comp", "if_nth_else")([component], component, "0", "a", "b") == "a"
-    assert reg.get("Comp", "if_nth_else")([component], component, "1", "a", "b") == "b"
+    ctx = generator.Context(spec=[component], comp=component, attr=None, namespace="Comp")
 
-    assert reg.get("Comp", "if_first")([component], component, "a") == "a"
-    assert reg.get("Comp", "if_not_first")([component], component, "a") == ""
-    assert reg.get("Comp", "if_last")([component], component, "a") == "a"
-    assert reg.get("Comp", "if_not_last")([component], component, "a") == ""
+    assert reg.get("Comp", "if_nth_else")(ctx, "0", "a", "b") == "a"
+    assert reg.get("Comp", "if_nth_else")(ctx, "1", "a", "b") == "b"
+
+    assert reg.get("Comp", "if_first")(ctx, "a") == "a"
+    assert reg.get("Comp", "if_not_first")(ctx, "a") == ""
+    assert reg.get("Comp", "if_last")(ctx, "a") == "a"
+    assert reg.get("Comp", "if_not_last")(ctx, "a") == ""

--- a/test/unit/test_method_register.py
+++ b/test/unit/test_method_register.py
@@ -45,18 +45,18 @@ def dummy(spec, obj):
 
 
 def test_custom_function_lookup_success(reg):
-    reg.attrmethod("test.func")(dummy)
-    assert reg.get("Attr", "test.func") == dummy
+    reg.attrmethod(dummy)
+    assert reg.get("Attr", "dummy") == dummy
 
 
 def test_context_cannot_register_a_custom_method_twice(reg):
-    reg.compmethod("foo")(dummy)
+    reg.compmethod(dummy)
     with pytest.raises(RuntimeError):
-        reg.compmethod("foo")(dummy)
+        reg.compmethod(dummy)
 
-    reg.attrmethod("bar")(dummy)
+    reg.attrmethod(dummy)
     with pytest.raises(RuntimeError):
-        reg.attrmethod("bar")(dummy)
+        reg.attrmethod(dummy)
 
 
 @pytest.mark.parametrize("key,value", [
@@ -66,12 +66,25 @@ def test_context_cannot_register_a_custom_method_twice(reg):
     (1, 2)
 ])
 def test_property_access_comp(reg, key, value):
-    obj = {key: value}
-    ctx = generator.Context(spec=[obj], comp=obj, attr=None, namespace="Comp")
+    comp = {key: value}
+    ctx = generator.Context(spec=[comp], comp=comp, attr=None, namespace="Comp")
     assert reg.get("Comp", key)(ctx) == value
 
 
-def test_builtin_conditionals(reg, component):
+@pytest.mark.parametrize("key,value", [
+    ("name", "datamatic"),
+    ("display_name", "Datamatic"),
+    ("a", "abc"),
+    (1, 2)
+])
+def test_property_access_attr(reg, key, value):
+    attr = {key: value}
+    comp = {"attributes": [attr]}
+    ctx = generator.Context(spec=[], comp=comp, attr=attr, namespace="Attr")
+    assert reg.get("Attr", key)(ctx) == value
+
+
+def test_builtin_conditionals_comp(reg, component):
     ctx = generator.Context(spec=[component], comp=component, attr=None, namespace="Comp")
 
     assert reg.get("Comp", "if_nth_else")(ctx, "0", "a", "b") == "a"
@@ -81,3 +94,16 @@ def test_builtin_conditionals(reg, component):
     assert reg.get("Comp", "if_not_first")(ctx, "a") == ""
     assert reg.get("Comp", "if_last")(ctx, "a") == "a"
     assert reg.get("Comp", "if_not_last")(ctx, "a") == ""
+
+
+def test_builtin_conditionals_attr(reg, attribute):
+    comp = {"attributes": [attribute]}
+    ctx = generator.Context(spec=[comp], comp=comp, attr=attribute, namespace="Attr")
+
+    assert reg.get("Attr", "if_nth_else")(ctx, "0", "a", "b") == "a"
+    assert reg.get("Attr", "if_nth_else")(ctx, "1", "a", "b") == "b"
+
+    assert reg.get("Attr", "if_first")(ctx, "a") == "a"
+    assert reg.get("Attr", "if_not_first")(ctx, "a") == ""
+    assert reg.get("Attr", "if_last")(ctx, "a") == "a"
+    assert reg.get("Attr", "if_not_last")(ctx, "a") == ""


### PR DESCRIPTION
* The first argument of replacement functions are now a `Context` object again. This contains the filtered spec, the current component, the current attribute (if in an `attrmethod`, otherwise it is `None`). It also has a `namespace` property which returns "Attr" if and only if the `attr` member is not `None`.
* `generator.run` now returns `True` if it generated or modified a file. If there was no change it returns `False`.
* With the above, `main.main` now returns the number of files it generated.
* Disallow providing a function name in the `*method` decorators. Now, just the function name is used instead. This is just to keep things simple; adding complexity in the decorators didn't really add any benefit.
* Now that the `Context` object in an `attrmethod` also provides the current component, there are now implementations of the conditional builtin functions for `attrmethod`s. This makes it possible to generate C++ constructors with ease.