### PR TITLE
Properly Parse Function Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ We briefly mentioned earlier that replacement tokens can accept arguments, so le
 ```cpp
 using ECS = TemplatedECS<
 DATAMATIC_BEGIN
-    {{Comp::name}}{{Comp::if_not_last(,)}}
+    {{Comp::name}}{{Comp::if_not_last(",")}}
 DATAMATIC_END
 >;
 ```
@@ -230,6 +230,8 @@ These arguments are then passed to the function definition in the order they app
     def if_not_last(ctx, arg):
 ```
 Notice that if the template calls the function with an incorrect number of arguments, an exception will be raised when trying to call this function.
+
+Another thing to note is that the parameter parsing is done by passing the contents in the parentheses to `ast.literal_eval`, so the parameters can be any of pythons primitive types, including lists, sets and dictionaries. However, note that if you use a set or dictionary, the curly braces could interfere with the parsing. For example, `{{Comp::if_not_last({1: "a": 2: {"b", "c"}})}}` could cause issues as the token would be parsed as `Comp::if_not_last({1: "a": 2: {"b", "c"`. Of course using anything other than a string for this function is probably unintended, but this is something users should be aware of when defining their own functions.
 
 ### Custom Data
 As mentioned, the properties that you choose to have on your components/attributes can be anything you want. It may also be useful to have properties that don't exist on all components, which should not be access directly in template files by attribute lookup, but may be used in custom functions.
@@ -277,7 +279,3 @@ Then in the function you could write
 If a property is not intended to be called directly from templates, there is no need to restrict them to being strings (technically nothing is stopping you from using non-strings for accessable properties, but the generated code may be weird as the value will be stringified).
 
 With the ability to generate template code using the full power of python, it should be possible to generate any kind of code you want. If there are still limitations, let me know, I would love to extend datamatic further to make it more useful!
-
-## Future
-* Have a nicer syntax for custom function parameters. I would like to make the arguments comma separated and allow "," to be an argument as well. For this I will add a more sophisticated parser, but I haven't done it yet. After doing this, `Comp::if_not_last(,)` would become `Comp::if_not_last(",")` which is more akin to what people should expect.
-* I've considered having inline python code in the templates akin to using `eval`, which is often seen as dangerous, but we are already executing arbitrary code via the `dmx` system, so maybe it's no worse. I'm also considering going the other way and removing the discovery system and making users have to specify the extension files on the command line instead, but I haven't reached a conclusion here.

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -28,7 +28,6 @@ class Token:
     raw_string: Optional[str] = field(default=None, compare=False)
 
 
-
 def parse_token_string(raw_string: str) -> Token:
     """
     Format:

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -3,6 +3,7 @@ from typing import Tuple, Literal, Optional
 from dataclasses import dataclass, field
 from functools import partial
 import parse
+import ast
 
 
 TOKEN = re.compile(r"\{\{(.*?)\}\}")
@@ -27,46 +28,6 @@ class Token:
     raw_string: Optional[str] = field(default=None, compare=False)
 
 
-def parse_argument_list(argument_list: str) -> Tuple[str]:
-    """
-    Splits a string representing an argument list into a typle of arguments
-
-    Exmaples:
-    '",", "a", "5"' -> (",", "a", "5")
-    """
-    quotes = {"'", '"'}
-
-    args = []
-    current_symbol = ""
-    current_quote = None
-    parsing_symbol = False
-    for symbol in argument_list:
-        if parsing_symbol:
-            if symbol == current_quote: # End of symbol
-                parsing_symbol = False
-            else:
-                current_symbol += symbol
-        else:
-            if symbol in quotes:
-                current_quote = symbol
-                parsing_symbol = True
-            elif symbol == ",":
-                if current_symbol == "":
-                    raise SyntaxError(f"Failed to parse {argument_list}")
-                args.append(current_symbol)
-                current_symbol = ""
-            elif symbol == " ":
-                pass
-            else:
-                raise SyntaxError(f"Failed to parse {argument_list}")
-
-    if parsing_symbol: # Didn't close off the last symbol
-        raise SyntaxError(f"Failed to parse {argument_list}")
-    if current_symbol is not None:
-        args.append(current_symbol)
-    return tuple(args)
-
-
 
 def parse_token_string(raw_string: str) -> Token:
     """
@@ -81,7 +42,7 @@ def parse_token_string(raw_string: str) -> Token:
         namespace, rest = raw_string.split("::")
         if result := parse.parse("{}({})", rest):
             function_name = result[0]
-            args = parse_argument_list(result[1])
+            args = tuple(ast.literal_eval(result[1]))
         elif result := parse.parse("{}()", rest):
             function_name = result[0]
             args = tuple()

--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -36,33 +36,33 @@ class MethodRegister:
 
         @self.compmethod
         @self.attrmethod
-        def if_nth_else(ctx, n, yes_token, no_token):
+        def if_nth_else(ctx, n: int, yes_token: str, no_token:str) -> str:
             try:
                 if ctx.namespace == "Comp":
-                    return yes_token if ctx.comp == ctx.spec[int(n)] else no_token
-                return yes_token if ctx.attr == ctx.comp["attributes"][int(n)] else no_token
+                    return yes_token if ctx.comp == ctx.spec[n] else no_token
+                return yes_token if ctx.attr == ctx.comp["attributes"][n] else no_token
             except IndexError:
                 return no_token
 
         @self.compmethod
         @self.attrmethod
         def if_first(ctx, token):
-            return if_nth_else(ctx, "0", token, "")
+            return if_nth_else(ctx, 0, token, "")
 
         @self.compmethod
         @self.attrmethod
         def if_not_first(ctx, token):
-            return if_nth_else(ctx, "0", "", token)
+            return if_nth_else(ctx, 0, "", token)
 
         @self.compmethod
         @self.attrmethod
         def if_last(ctx, token):
-            return if_nth_else(ctx, "-1", token, "")
+            return if_nth_else(ctx, -1, token, "")
 
         @self.compmethod
         @self.attrmethod
         def if_not_last(ctx, token):
-            return if_nth_else(ctx, "-1", "", token)
+            return if_nth_else(ctx, -1, "", token)
 
     def load_from_dmx(self, directory: pathlib.Path):
         """

--- a/test/integration/actual.dm.cpp
+++ b/test/integration/actual.dm.cpp
@@ -16,13 +16,13 @@ DATAMATIC_END
 // Test Flags
 std::vector<std::string> types_with_flag_a_true = {
 DATAMATIC_BEGIN FLAG_A=true
-    "{{Comp::name}}"{{Comp::if_not_last(,)}}
+    "{{Comp::name}}"{{Comp::if_not_last(",")}}
 DATAMATIC_END
 };
 
 std::vector<std::string> types_with_flag_b_false = {
 DATAMATIC_BEGIN FLAG_B=false
-    "{{Comp::test_function}}"{{Comp::if_not_last(,)}}
+    "{{Comp::test_function}}"{{Comp::if_not_last(",")}}
 DATAMATIC_END
 };
 

--- a/test/integration/invalid.dm.cpp
+++ b/test/integration/invalid.dm.cpp
@@ -12,7 +12,7 @@ struct {{Comp::name}}
 };
 
 DATAMATIC_BEGIN
-    "{{Comp::name}}"{{Comp::if_not_last(,)}}
+    "{{Comp::name}}"{{Comp::if_not_last(",")}}
 DATAMATIC_END
 DATAMATIC_END
 };

--- a/test/unit/test_generator.py
+++ b/test/unit/test_generator.py
@@ -6,19 +6,9 @@ from pathlib import Path
 
 @pytest.mark.parametrize("raw,token", [
     ("Comp::foo", Token("Comp", "foo", tuple())),
-    ("Comp::foo(a)", Token("Comp", "foo", ("a",))),
-    ("Comp::foo(a|b)", Token("Comp", "foo", ("a", "b"))),
-    ("Comp::foo(a|b|c)", Token("Comp", "foo", ("a", "b", "c"))),
-
-    ("Comp::foo.bar", Token("Comp", "foo.bar", tuple())),
-    ("Comp::foo.bar(a)", Token("Comp", "foo.bar", ("a",))),
-    ("Comp::foo.bar(a|b)", Token("Comp", "foo.bar", ("a", "b"))),
-    ("Comp::foo.bar(a|b|c)", Token("Comp", "foo.bar", ("a", "b", "c"))),
-
-    ("Comp::foo.bar.baz", Token("Comp", "foo.bar.baz", tuple())),
-    ("Comp::foo.bar.baz(a)", Token("Comp", "foo.bar.baz", ("a",))),
-    ("Comp::foo.bar.baz(a|b)", Token("Comp", "foo.bar.baz", ("a", "b"))),
-    ("Comp::foo.bar.baz(a|b|c)", Token("Comp", "foo.bar.baz", ("a", "b", "c"))),
+    ("Comp::foo()", Token("Comp", "foo", tuple())),
+    ("Comp::foo('a')", Token("Comp", "foo", ("a",))),
+    ("Comp::foo('a', 'b')", Token("Comp", "foo", ("a", "b"))),
 ])
 def test_parse_token_string_success(raw, token):
     assert token == generator.parse_token_string(raw)
@@ -31,9 +21,9 @@ def test_empty_parentheses_is_valid():
 @pytest.mark.parametrize("raw", [
     "Comp",
     "Comp::foo::bar"
-    "Comp::foo(a"
-    "Comp::foo(a|"
-    "Comp::foo(a|b|)"
+    "Comp::foo('a'"
+    "Comp::foo('a',"
+    "Comp::foo('a', 'b',)"
 ])
 def test_parse_token_string_failure(raw):
     with pytest.raises(RuntimeError):
@@ -189,31 +179,3 @@ def test_empty_flag_application():
     ]
 
     assert generator.apply_flags_to_spec(spec, {}) == expected
-
-
-@pytest.mark.parametrize("argument_list,expected", [
-    ('"a", "b", "c"', ("a", "b", "c")),
-    ('",", "b", "c"', (",", "b", "c")),
-    ('"a", "b", "c" "d"', ("a", "b", "cd")), # Comma splits args, consecutive string concatenate
-    ('"a" \'b\', "c",    "d"', ("ab", "c", "d")),
-    ('" "', (" ",)),
-    ('"a"', ("a",)),
-    ('" ", "a", "b "', (" ", "a", "b ")),
-    ("    'a', 'b'", ("a", "b")),
-    (""" "a", "b" """, ("a", "b")),
-    (""" "a", 'b' """, ("a", "b")),
-    ('","', (",",))
-])
-def test_parse_argument_list(argument_list, expected):
-    assert generator.parse_argument_list(argument_list) == expected
-
-
-@pytest.mark.parametrize("argument_list", [
-    "'a', 'b", # Unpaied quotes
-    "a, b, c" # No quotes
-    '"a",,"b"', # Consecutive commas
-    """ "a' """, # Mismatching quotes
-])
-def test_parse_argument_list_failure(argument_list):
-    with pytest.raises(SyntaxError):
-        generator.parse_argument_list(argument_list)

--- a/test/unit/test_method_register.py
+++ b/test/unit/test_method_register.py
@@ -4,6 +4,7 @@ Test driver for the builtin comp and attr methods.
 from datamatic import method_register, generator
 import pytest
 
+
 @pytest.fixture
 def reg():
     """

--- a/test/unit/test_method_register.py
+++ b/test/unit/test_method_register.py
@@ -87,8 +87,8 @@ def test_property_access_attr(reg, key, value):
 def test_builtin_conditionals_comp(reg, component):
     ctx = generator.Context(spec=[component], comp=component, attr=None)
 
-    assert reg.get("Comp", "if_nth_else")(ctx, "0", "a", "b") == "a"
-    assert reg.get("Comp", "if_nth_else")(ctx, "1", "a", "b") == "b"
+    assert reg.get("Comp", "if_nth_else")(ctx, 0, "a", "b") == "a"
+    assert reg.get("Comp", "if_nth_else")(ctx, 1, "a", "b") == "b"
 
     assert reg.get("Comp", "if_first")(ctx, "a") == "a"
     assert reg.get("Comp", "if_not_first")(ctx, "a") == ""
@@ -100,8 +100,8 @@ def test_builtin_conditionals_attr(reg, attribute):
     comp = {"attributes": [attribute]}
     ctx = generator.Context(spec=[comp], comp=comp, attr=attribute)
 
-    assert reg.get("Attr", "if_nth_else")(ctx, "0", "a", "b") == "a"
-    assert reg.get("Attr", "if_nth_else")(ctx, "1", "a", "b") == "b"
+    assert reg.get("Attr", "if_nth_else")(ctx, 0, "a", "b") == "a"
+    assert reg.get("Attr", "if_nth_else")(ctx, 1, "a", "b") == "b"
 
     assert reg.get("Attr", "if_first")(ctx, "a") == "a"
     assert reg.get("Attr", "if_not_first")(ctx, "a") == ""


### PR DESCRIPTION
* Functions parameters in template tokens are now proper python-style signatures. For example `Comp::if_nth_else(0|:|,)` must now be written as `Comp::if_nth_else(0, ":", ",")`.
* Uses `ast.literal_eval` for the parsing, so arguments can be strings, ints, float, lists, tuples, etc. Nested dictionaries that produce a `}}` will break the parser, must write as `} }` to work properly (like C++03 `>>`).