### PR TITLE
Make Flags Optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.8"
   - "3.9"
   - "3.9-dev"
   - "nightly"

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -62,6 +62,10 @@ def apply_flags_to_spec(spec, flags):
     Returns a copy of the component list but with the given flags applied; any component or
     attribute that doesn't match the given flags are omitted.
     """
+    # If we are not using flags, then no filtering is required.
+    if "flag_defaults" not in spec:
+        return spec
+
     components = []
     for comp in spec["components"]:
         if all(comp['flags'][key] == value for key, value in flags.items()):

--- a/datamatic/main.py
+++ b/datamatic/main.py
@@ -16,6 +16,9 @@ def load_spec(specfile: pathlib.Path):
 
 
 def fill_flag_defaults(spec):
+    if "flag_defaults" not in spec:
+        return
+        
     defaults = spec["flag_defaults"]
     for comp in spec["components"]:
         comp_flags = comp.get("flags", {})

--- a/datamatic/validator.py
+++ b/datamatic/validator.py
@@ -2,6 +2,7 @@
 Validates a given schema to make sure it is well-formed. This should
 also serve as documentation for what makes a valid schema.
 """
+from typing import Optional
 
 
 class InvalidSpecError(RuntimeError):
@@ -20,10 +21,17 @@ def assert_property(object, property: str):
         raise InvalidSpecError(f"'{property}' is missing from {object}")
 
 
-def validate_flags_on_object(flags, flag_names):
+def validate_flags_on_object(obj, flag_names: Optional[set[str]]):
     """
     Given an object, verify that it is a (str -> bool) dict.
     """
+    flags = obj.get("flags")
+
+    # If there are no default values for flags, then this spec is not making use of flags,
+    # so components/attributes should not have a "flags" field.
+    if flag_names is None and flags is not None:
+        raise InvalidSpecError(f"'default_flags' is not provided, but flags exist on {obj}")
+
     assert_type(flags, dict)
     if set(flags.keys()) != flag_names:
         raise InvalidSpecError(f"Invalid flags set, got {set(flags.keys())}, expected {flag_names}")
@@ -33,17 +41,17 @@ def validate_flags_on_object(flags, flag_names):
         assert_type(value, bool)
 
 
-def validate_attribute(attr, flag_names):
+def validate_attribute(attr, flag_names: Optional[set[str]]):
     assert_property(attr, "flags")
-    validate_flags_on_object(attr["flags"], flag_names)
+    validate_flags_on_object(attr, flag_names)
 
 
-def validate_component(comp, flag_names):
+def validate_component(comp, flag_names: Optional[set[str]]):
     """
     Asserts that the given component is well-formed.
     """
     assert_property(comp, "flags")
-    validate_flags_on_object(comp["flags"], flag_names)
+    validate_flags_on_object(comp, flag_names)
 
     assert_property(comp, "attributes")
     assert_type(comp["attributes"], list)
@@ -56,21 +64,22 @@ def run(spec):
     Runs the validator against the given spec, raising an exception if there
     is an error in the schema.
     """
-    if "flag_defaults" not in spec:
-        raise InvalidSpecError("Spec must contain 'flag_defaults'")
+    for key in spec:
+        if key not in {"flag_defaults", "components"}:
+            raise InvalidSpecError(f"Spec has invalid top-level key: {key}")
+            
+    flag_names: Optional[set[str]] = None
+    if spec_flags := spec.get("flag_defaults"):
+        assert_type(spec_flags, dict)
+        flag_names = set(spec_flags.keys())
+        for flag_name, value in spec_flags.items():
+            assert_type(flag_name, str)
+            assert_type(value, bool)
+
     if "components" not in spec:
         raise InvalidSpecError("Spec must contain 'components'")
-
-    spec_flags = spec["flag_defaults"]
-    assert_type(spec_flags, dict)
-    for flag_name, value in spec_flags.items():
-        assert_type(flag_name, str)
-        assert_type(value, bool)
-
     spec_components = spec["components"]
     assert_type(spec_components, list)
-
-    flag_names = set(spec_flags.keys())
 
     for comp in spec["components"]:
         validate_component(comp, flag_names)

--- a/test/unit/test_generator.py
+++ b/test/unit/test_generator.py
@@ -61,13 +61,10 @@ def test_process_block():
     lines = [
         r"{{Comp::name}} -> {{Comp::display_name}}"
     ]
-    spec = {
-        "flags": [],
-        "components": [
-            {"name": "first", "display_name": "1st", "attributes": []},
-            {"name": "second", "display_name": "2nd", "attributes": []}
-        ]
-    }
+    spec = [
+        {"name": "first", "display_name": "1st", "attributes": []},
+        {"name": "second", "display_name": "2nd", "attributes": []}
+    ]
     reg = method_register.MethodRegister()
     reg.load_builtins()
 
@@ -172,3 +169,25 @@ def test_empty_flag_application():
     ]
 
     assert generator.apply_flags_to_spec(spec, {}) == expected
+
+
+def test_flagless_spec():
+    spec = {
+        "components": [
+            {
+                "name": "a",
+                "attributes": []
+            },
+            {
+                "name": "b",
+                "attributes": []
+            },
+            {
+                "name": "c",
+                "attributes": []
+            },
+        ]
+    }
+    main.fill_flag_defaults(spec)
+
+    assert generator.apply_flags_to_spec(spec, {}) == spec

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -54,15 +54,15 @@ def test_validate_flags_on_object():
 
     # foo is not a valid flag
     with pytest.raises(InvalidSpecError):
-        validator.validate_flags_on_object({"foo": True}, {"bar"})
+        validator.validate_flags_on_object({"flags": {"foo": True}}, {"bar"})
 
     # keys must be a str
     with pytest.raises(InvalidSpecError):
-        validator.validate_flags_on_object({1: True}, {1})
+        validator.validate_flags_on_object({"flags": {1: True}}, {1})
 
     # value must be a bool
     with pytest.raises(InvalidSpecError):
-        validator.validate_flags_on_object({"foo": 1}, {"foo"})
+        validator.validate_flags_on_object({"flags": {"foo": 1}}, {"foo"})
 
 
 def test_validate_component_missing_required_key():
@@ -115,3 +115,9 @@ def test_validator_components_must_be_a_list():
     spec = {"flags_defaults": {}, "components": None}
     with pytest.raises(InvalidSpecError):
         validator.run(spec)
+
+    
+def test_objects_cant_have_flags_if_no_defaults():
+    obj = {"flags": {}}
+    with pytest.raises(InvalidSpecError):
+        validator.validate_flags_on_object(obj, None)

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -6,14 +6,9 @@ from datamatic.validator import InvalidSpecError
 import pytest
 
 
-def test_spec_missing_required_keys():
-    spec = {"components": []}
+def test_spec_missing_components_key():
     with pytest.raises(InvalidSpecError):
-        validator.run(spec)
-
-    spec = {"flag_defaults": {}}
-    with pytest.raises(InvalidSpecError):
-        validator.run(spec)
+        validator.run({})
 
 
 def test_validate_attribute_missing_required_key():
@@ -55,7 +50,7 @@ def test_validate_attribute_types():
 def test_validate_flags_on_object():
     # obj must be a dict
     with pytest.raises(InvalidSpecError):
-        validator.validate_flags_on_object([], set())
+        validator.validate_flags_on_object({}, set())
 
     # foo is not a valid flag
     with pytest.raises(InvalidSpecError):
@@ -104,11 +99,6 @@ def test_validate_component_types():
 
 
 def test_validator_run():
-    # doesn't have the correct keys
-    spec = {}
-    with pytest.raises(InvalidSpecError):
-        validator.run(spec)
-
     # has invalid extra keys
     spec = {"flags_defaults": {}, "components": [], "extra": []}
     with pytest.raises(InvalidSpecError):


### PR DESCRIPTION
* `flag_defaults` is now an optional field.
* If `flag_defaults` is not provided, but a component or attribute has `flags`, that is an error.
* Drop support for python3.8.