### PR TITLE
Add filename to errors

### DIFF
--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -28,10 +28,6 @@ class Context:
     def namespace(self):
         return "Attr" if self.attr is not None else "Comp"
 
-    @property
-    def object(self):
-        return self.attr if self.attr is not None else self.comp
-
 
 @dataclass(frozen=True)
 class Token:

--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -29,14 +29,6 @@ class MethodRegister:
             return lambda ctx: ctx.comp[function_name]
         return lambda ctx: ctx.attr[function_name]
 
-    def __getattr__(self, attr_name):
-        if ("Comp", attr_name) in self.methods:
-            return self.methods["Comp", attr_name]
-        if ("Attr", attr_name) in self.methods:
-            return self.methods["Attr", attr_name]
-        return NotImplemented
-
-
     def load_builtins(self):
         """
         A function for loading a bunch of built in custom functions.

--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -29,6 +29,14 @@ class MethodRegister:
             return lambda ctx: ctx.comp[function_name]
         return lambda ctx: ctx.attr[function_name]
 
+    def __getattr__(self, attr_name):
+        if ("Comp", attr_name) in self.methods:
+            return self.methods["Comp", attr_name]
+        if ("Attr", attr_name) in self.methods:
+            return self.methods["Attr", attr_name]
+        return NotImplemented
+
+
     def load_builtins(self):
         """
         A function for loading a bunch of built in custom functions.
@@ -63,6 +71,14 @@ class MethodRegister:
         @self.attrmethod
         def if_not_last(ctx, token):
             return if_nth_else(ctx, -1, "", token)
+
+        @self.compmethod
+        def attr_count(ctx):
+            return str(len(ctx.comp["attributes"]))
+
+        @self.compmethod
+        def attr_list(ctx, field, separator, format="{}"):
+            return separator.join(format.format(attr[field]) for attr in ctx.comp["attributes"])
 
     def load_from_dmx(self, directory: pathlib.Path):
         """

--- a/test/unit/test_generator.py
+++ b/test/unit/test_generator.py
@@ -11,11 +11,11 @@ from pathlib import Path
     ("Comp::foo('a', 'b')", Token("Comp", "foo", ("a", "b"))),
 ])
 def test_parse_token_string_success(raw, token):
-    assert token == generator.parse_token_string(raw)
+    assert token == generator.parse_token_string("file", raw)
 
 
 def test_empty_parentheses_is_valid():
-    assert generator.parse_token_string("Comp::foo()") == Token("Comp", "foo", tuple())
+    assert generator.parse_token_string("file", "Comp::foo()") == Token("Comp", "foo", tuple())
 
 
 @pytest.mark.parametrize("raw", [
@@ -26,8 +26,8 @@ def test_empty_parentheses_is_valid():
     "Comp::foo('a', 'b',)"
 ])
 def test_parse_token_string_failure(raw):
-    with pytest.raises(RuntimeError):
-        generator.parse_token_string(raw)
+    with pytest.raises(generator.GeneratorError):
+        generator.parse_token_string("file", raw)
 
 
 def test_parse_flag_value():
@@ -68,7 +68,7 @@ def test_process_block():
     reg = method_register.MethodRegister()
     reg.load_builtins()
 
-    assert generator.process_block(lines, {}, spec, reg) == "first -> 1st\nsecond -> 2nd\n"
+    assert generator.process_block("file", lines, {}, spec, reg) == "first -> 1st\nsecond -> 2nd\n"
 
 
 def test_flag_application():


### PR DESCRIPTION
* When an error occurs, the file it occured in is printed.
* When substituting a `Comp` token, if it results in an empty line, it is skipped.
* Added `Comp::attr_count` and `Comp::attr_list` to the builtin functions.