### PR TITLE
Package Mode

### DIFF
--- a/datamatic.py
+++ b/datamatic.py
@@ -67,5 +67,7 @@ if __name__ == "__main__":
     spec = args.spec
     if args.command == "inplace":
         main.main_inplace(spec, args.dir)
-    else:
+    elif args.command == "package":
         main.main_package(spec, args.src, args.dst)
+    else:
+        print("No command specified")

--- a/datamatic.py
+++ b/datamatic.py
@@ -5,6 +5,17 @@ import argparse
 import pathlib
 from datamatic import main
 
+inplace_help = """\
+Scans the given directory, importing all dmx files it finds and producing source files
+that sit alongside the template files.
+"""
+
+package_help = """\
+Given a source dir and a destination dir, import all dmx files found in the source dir, and make
+a copy of the entire source dir saved as the destination. Template files are replaced by the
+rendered source code and all datamatic files are removed. Any non-template files in the source
+are copied over.
+"""
 
 def parse_args():
     """
@@ -23,11 +34,29 @@ def parse_args():
         help="A path to the component spec JSON file"
     )
 
-    parser.add_argument(
-        "-d", "--dir",
+    subparsers = parser.add_subparsers(dest="command")
+
+    inplace = subparsers.add_parser("inplace", help=inplace_help)
+    inplace.add_argument(
+        "--dir",
         required=True,
         type=pathlib.Path,
         help="A path to the directory to scan for dm and dmx files"
+    )
+
+    package = subparsers.add_parser("package", help=package_help)
+    package.add_argument(
+        "--src",
+        required=True,
+        type=pathlib.Path,
+        help="A path to the source directory that contains dm, dmx and regular files"
+    )
+
+    package.add_argument(
+        "--dst",
+        required=True,
+        type=pathlib.Path,
+        help="A path to the dest directory that will contain all rendered files"
     )
 
     return parser.parse_args()
@@ -35,4 +64,8 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    main.main(args.spec, args.dir)
+    spec = args.spec
+    if args.command == "inplace":
+        main.main_inplace(spec, args.dir)
+    else:
+        main.main_package(spec, args.src, args.dst)

--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -155,9 +155,7 @@ def parse_flags(flags):
     return parsed_flags
 
 
-def run(src, spec, method_register):
-    dst = src.parent / src.name.replace(".dm.", ".")
-
+def run(src, dst, spec, method_register):
     with src.open() as srcfile:
         lines = srcfile.readlines()
 

--- a/datamatic/main.py
+++ b/datamatic/main.py
@@ -67,10 +67,10 @@ def main_package(specfile: pathlib.Path, src: pathlib.Path, dst: pathlib.Path):
     os.mkdir(str(dst))
 
     count = 0
-    plugins = set(src.glob("**/*.dmx.py"))
+    ignore = set(src.glob("**/*.dmx.py")) | set(src.glob("**/*.pyc"))
     templates = set(src.glob("**/*.dm.*"))
     for srcfile in src.glob("**/*"):
-        if srcfile in plugins:
+        if srcfile in ignore:
             continue  # Ignore plugins
 
         if srcfile in templates:
@@ -79,7 +79,10 @@ def main_package(specfile: pathlib.Path, src: pathlib.Path, dst: pathlib.Path):
                 count += 1
         else:
             dstfile = dst / srcfile.name
-            shutil.copy(srcfile, dstfile)
+            try:
+                shutil.copy(srcfile, dstfile)
+            except PermissionError:
+                pass
 
     print(f"Done! Generated {count} files")
     return count

--- a/datamatic/main.py
+++ b/datamatic/main.py
@@ -39,8 +39,9 @@ def main_inplace(specfile: pathlib.Path, directory: pathlib.Path):
     reg.load_from_dmx(directory)
 
     count = 0
-    for file in directory.glob("**/*.dm.*"):
-        if generator.run(file, spec, reg):
+    for src in directory.glob("**/*.dm.*"):
+        dst = src.parent / src.name.replace(".dm.", ".")
+        if generator.run(src, dst, spec, reg):
             count += 1
 
     print(f"Done! Generated {count} files")
@@ -56,3 +57,4 @@ def main_package(specfile: pathlib.Path, src: pathlib.Path, dst: pathlib.Path):
     reg = method_register.MethodRegister()
     reg.load_builtins()
     reg.load_from_dmx(src)
+

--- a/datamatic/main.py
+++ b/datamatic/main.py
@@ -28,9 +28,9 @@ def fill_flag_defaults(spec):
             attr["flags"] = {**defaults, **attr_flags}
 
 
-def main(specfile: pathlib.Path, directory: pathlib.Path):
+def main_inplace(specfile: pathlib.Path, directory: pathlib.Path):
     """
-    Entry point.
+    Entry point for the inplace tool.
     """
     spec = load_spec(specfile)
 
@@ -45,3 +45,14 @@ def main(specfile: pathlib.Path, directory: pathlib.Path):
 
     print(f"Done! Generated {count} files")
     return count
+
+
+def main_package(specfile: pathlib.Path, src: pathlib.Path, dst: pathlib.Path):
+    """
+    Entry point for the package tool.
+    """
+    spec = load_spec(specfile)
+
+    reg = method_register.MethodRegister()
+    reg.load_builtins()
+    reg.load_from_dmx(src)

--- a/test/integration/test_end_to_end.py
+++ b/test/integration/test_end_to_end.py
@@ -25,7 +25,7 @@ def copy_file(src_dir: Path, out_dir: Path, filename: str, new_filename: Optiona
     assert new_file.exists()
 
 
-def test_end_to_end_simple(src_path, tmp_path):
+def test_end_to_end_inplace(src_path, tmp_path):
     """
     Creates a temporary directory and copies the template file. Run datamatic on the directory
     and verify that a new file as been created with the same contents as the expected file.
@@ -37,7 +37,7 @@ def test_end_to_end_simple(src_path, tmp_path):
     copy_file(src_path, tmp_path, "custom_functions.dmx.py")
 
     specfile = src_path / "component_spec.json"
-    assert main.main(specfile, tmp_path) == 1  # Assert one file is generated
+    assert main.main_inplace(specfile, tmp_path) == 1  # Assert one file is generated
 
     expected_file = src_path / "expected.cpp"
     actual_file = tmp_path / "actual.cpp"
@@ -59,4 +59,4 @@ def test_file_is_not_rewritten_if_no_change(src_path, tmp_path):
     copy_file(src_path, tmp_path, "expected.cpp", "actual.cpp")
 
     specfile = src_path / "component_spec.json"
-    assert main.main(specfile, tmp_path) == 0
+    assert main.main_inplace(specfile, tmp_path) == 0

--- a/test/integration/test_mismatched_datamatic_blocks.py
+++ b/test/integration/test_mismatched_datamatic_blocks.py
@@ -28,4 +28,4 @@ def test_mismatched_datamatic_blocks():
 
     # THEN
     with pytest.raises(RuntimeError):
-        main.main(specfile, pathlib.Path(out_dir))
+        main.main_inplace(specfile, pathlib.Path(out_dir))


### PR DESCRIPTION
* Add a second mode to datamatic. Current mode is now called `inplace` as it recurses over the given directory and creates copies of files in place.
* New mode is called `package`, for this you specify a source directory and a target directory, and the target directory is cleared and created as a copy of the source directory with all of the `dm` files fully rendered. All plugins must be in the source directory and they do not get copied over.
* Any non-datamatic files in the source directory are copied over without changing.