### PR TITLE
Remove Spec Filtering

### DIFF
--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -7,6 +7,8 @@ import pathlib
 import importlib.util
 from functools import partialmethod
 
+from . import utilities
+
 
 class MethodRegister:
     def __init__(self):
@@ -39,8 +41,10 @@ class MethodRegister:
         def if_nth_else(ctx, n: int, yes_token: str, no_token:str) -> str:
             try:
                 if ctx.namespace == "Comp":
-                    return yes_token if ctx.comp == ctx.spec[n] else no_token
-                return yes_token if ctx.attr == ctx.comp["attributes"][n] else no_token
+                    comps = utilities.filter_flags(ctx.spec["components"], ctx.flags)
+                    return yes_token if ctx.comp == comps[n] else no_token
+                attrs = utilities.filter_flags(ctx.comp["attributes"], ctx.flags)
+                return yes_token if ctx.attr == attrs[n] else no_token
             except IndexError:
                 return no_token
 
@@ -66,11 +70,13 @@ class MethodRegister:
 
         @self.compmethod
         def attr_count(ctx):
-            return str(len(ctx.comp["attributes"]))
+            attrs = utilities.filter_flags(ctx.comp["attributes"], ctx.flags)
+            return str(len(attrs))
 
         @self.compmethod
         def attr_list(ctx, field, separator, format="{}"):
-            return separator.join(format.format(attr[field]) for attr in ctx.comp["attributes"])
+            attrs = utilities.filter_flags(ctx.comp["attributes"], ctx.flags)
+            return separator.join(format.format(attr[field]) for attr in attrs)
 
     def load_from_dmx(self, directory: pathlib.Path):
         """

--- a/datamatic/utilities.py
+++ b/datamatic/utilities.py
@@ -1,0 +1,17 @@
+"""
+A module of utility functions to be used in both the core datamatic implmentation as
+well as being made available to plugins.
+"""
+
+
+def flag_match(obj, flags):
+    assert "flags" in obj
+    return all(obj['flags'][key] == value for key, value in flags.items())
+
+
+def filter_flags(obj_list, flags):
+    """
+    Given a list of components or attributes, and a dict of flags, yield all objects in
+    the list that match the flags.
+    """
+    return [obj for obj in obj_list if flag_match(obj, flags)]

--- a/datamatic/utilities.py
+++ b/datamatic/utilities.py
@@ -5,13 +5,17 @@ well as being made available to plugins.
 
 
 def flag_match(obj, flags):
+    """
+    Given a component or attribute, return true if it matches all of the given flags
+    and False otherwise.
+    """
     assert "flags" in obj
     return all(obj['flags'][key] == value for key, value in flags.items())
 
 
 def filter_flags(obj_list, flags):
     """
-    Given a list of components or attributes, and a dict of flags, yield all objects in
-    the list that match the flags.
+    Given a list of components or attributes, and a dict of flags, return a list containing
+    only the objects that match the flags.
     """
     return [obj for obj in obj_list if flag_match(obj, flags)]


### PR DESCRIPTION
* Now, flags no longer get applied to the spec to reduce it down, giving plugin functions access to the spec directly.
* The old flag behaviour is still implemented by modifying the builtin functions such as `if_nth_else` to perform the flag filtering when counting.
* Added a `utilities` module to contain useful functions such as the flag filtering which may be wanted in plugin functions.