### PR TITLE
Add Global functions

### DIFF
--- a/datamatic/generator.py
+++ b/datamatic/generator.py
@@ -189,6 +189,18 @@ def run(src, dst, spec, method_register):
     for line in lines:
         line = line.rstrip()
 
+        # Globals can appear on any line, outside of Datamatic blocks
+        while "{{Global::" in line:
+            line = TOKEN.sub(partial(
+                replace_token,
+                file=src,
+                comp=None,
+                attr=None,
+                spec=spec,
+                flags=flags,
+                method_register=method_register
+            ), line)
+
         if in_block:
             if line.startswith("DATAMATIC_BEGIN"):
                 raise RuntimeError("Tried to begin a datamatic block while in another, cannot be nested")

--- a/datamatic/method_register.py
+++ b/datamatic/method_register.py
@@ -23,10 +23,13 @@ class MethodRegister:
 
     compmethod = partialmethod(register_method, namespace="Comp")
     attrmethod = partialmethod(register_method, namespace="Attr")
+    globalmethod = partialmethod(register_method, namespace="Global")
 
     def get(self, namespace, function_name):
         if (namespace, function_name) in self.methods:
             return self.methods[namespace, function_name]
+        if namespace == "Global":
+            return lambda ctx: ctx.spec[function_name]
         if namespace == "Comp":
             return lambda ctx: ctx.comp[function_name]
         return lambda ctx: ctx.attr[function_name]

--- a/datamatic/validator.py
+++ b/datamatic/validator.py
@@ -64,10 +64,6 @@ def run(spec):
     Runs the validator against the given spec, raising an exception if there
     is an error in the schema.
     """
-    for key in spec:
-        if key not in {"flag_defaults", "components"}:
-            raise InvalidSpecError(f"Spec has invalid top-level key: {key}")
-            
     flag_names: Optional[set[str]] = None
     if spec_flags := spec.get("flag_defaults"):
         assert_type(spec_flags, dict)

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -98,19 +98,6 @@ def test_validate_component_types():
         validator.validate_component(comp, [])
 
 
-def test_validator_run():
-    # has invalid extra keys
-    spec = {"flags_defaults": {}, "components": [], "extra": []}
-    with pytest.raises(InvalidSpecError):
-        validator.run(spec)
-
-
-def test_validator_flags_must_be_a_list():
-    spec = {"flags_defaults": None, "components": []}
-    with pytest.raises(InvalidSpecError):
-        validator.run(spec)
-
-
 def test_validator_components_must_be_a_list():
     spec = {"flags_defaults": {}, "components": None}
     with pytest.raises(InvalidSpecError):


### PR DESCRIPTION
* Now possible to have `{{Global::function_name}}` symbols. These can appear outside of datamatic blocks as well as inside, and get substituted first.
* Register them with `@globalmethod` in plugins.
* If no function is found, the attribute name is looked up in the top level of spec files, which is now allowed.